### PR TITLE
Add ec2 vpc endpoint policy for AWS resources

### DIFF
--- a/vpc_endpoint_policies/ec2_endpoint_policy.json
+++ b/vpc_endpoint_policies/ec2_endpoint_policy.json
@@ -1,0 +1,60 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowRequestsByOrgsIdentitiesToOrgsResources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "*",          
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:PrincipalOrgID": "<my-org-id>",
+                    "aws:ResourceOrgID": "<my-org-id>"
+                }
+            }
+        },
+        {
+            "Sid": "AllowRequestsByAWSServicePrincipals",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "*",
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "aws:PrincipalIsAWSService": "true"
+                }
+            }
+        },
+        {
+            "Sid": "AllowAPIsForAWSResources",
+            "Effect": "Allow",
+			"Principal": {
+				"AWS": "*"
+			},
+			"Action": [
+                "ec2:GetManagedPrefixList*"
+            ],
+			"Resource": "*"
+		},
+        {
+            "Sid": "AllowRequestsByOrgsIdentitiesToAnyResources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "*",
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:PrincipalOrgID": "<my-org-id>",
+                    "aws:PrincipalTag/resource-perimeter-exception": "true"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*
Default endpoint policy couldn't accept `ec2:GetManagedPrefixList` API.

*Description of changes:*
 So, we need new endpoint policy sample for EC2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
