### PR TITLE
VPC Endpoint policy updates

### DIFF
--- a/vpc_endpoint_policies/README.md
+++ b/vpc_endpoint_policies/README.md
@@ -53,6 +53,7 @@ Example data access patterns:
 
     * [AWS owned bucket for Kernel Live Patching on Amazon Linux 2023](https://docs.aws.amazon.com/linux/al2023/ug/live-patching.html):
         * `arn:aws:s3:::al2023-<region>/*`
+        * `arn:aws:s3:::al2023-repos-<region>-de612dc2/*`
 
 
 * *Amazon EMR patching and Spark logging.* Amazon EMR uses Amazon Linux repositories that are hosted in AWS owned Amazon S3 buckets to [launch and manage instances within Amazon EMR clusters](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-default-ami.html). Amazon EMR also collects [Spark event logs](https://docs.aws.amazon.com/emr/latest/ManagementGuide/app-history-spark-UI.html) in an AWS owned system bucket. To do so, Amazon EMR makes unauthenticated calls to Amazon S3. These calls originate from your VPC and pass through the Amazon S3 VPC endpoint. 

--- a/vpc_endpoint_policies/ec2_endpoint_policy copy.json
+++ b/vpc_endpoint_policies/ec2_endpoint_policy copy.json
@@ -43,7 +43,6 @@
                     "aws:PrincipalOrgID": "<my-org-id>",
                     "ec2:Owner": [
                         "amazon",
-                        "aws-marketplace",
                         "<AMI-building-account-id>"
                     ]
                 }

--- a/vpc_endpoint_policies/ec2_endpoint_policy copy.json
+++ b/vpc_endpoint_policies/ec2_endpoint_policy copy.json
@@ -42,8 +42,7 @@
                 "StringEquals": {
                     "aws:PrincipalOrgID": "<my-org-id>",
                     "ec2:Owner": [
-                        "amazon",
-                        "<AMI-building-account-id>"
+                        "amazon"
                     ]
                 }
             }

--- a/vpc_endpoint_policies/ec2_endpoint_policy copy.json
+++ b/vpc_endpoint_policies/ec2_endpoint_policy copy.json
@@ -7,7 +7,7 @@
             "Principal": {
                 "AWS": "*"
             },
-            "Action": "*",
+            "Action": "*",          
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
@@ -31,24 +31,21 @@
             }
         },
         {
-            "Sid": "AllowRequestsByOrgsIdentitiesToAWSResources",
+            "Sid": "AllowEC2Creation",
+            "Effect": "Allow",
             "Principal": {
                 "AWS": "*"
             },
-            "Action": [
-                "ssm:Describe*",
-                "ssm:List*",
-                "ssm:Get*",
-                "ssm:Start*"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-                "arn:aws:ssm:<region>::parameter/aws/*",
-                "arn:aws:ssm:<region>::document/*"
-            ],
+            "Action": "ec2:RunInstances",
+            "Resource": "*",
             "Condition": {
                 "StringEquals": {
-                    "aws:PrincipalOrgID": "<my-org-id>"
+                    "aws:PrincipalOrgID": "<my-org-id>",
+                    "ec2:Owner": [
+                        "amazon",
+                        "aws-marketplace",
+                        "<AMI-building-account-id>"
+                    ]
                 }
             }
         },

--- a/vpc_endpoint_policies/s3_endpoint_policy.json
+++ b/vpc_endpoint_policies/s3_endpoint_policy.json
@@ -46,6 +46,7 @@
                 "arn:aws:s3:::repo.<region>.amazonaws.com/*",
                 "arn:aws:s3:::amazonlinux.<region>.amazonaws.com/*",
                 "arn:aws:s3:::amazonlinux-2-repos-<region>/*",
+                "arn:aws:s3:::al2023-repos-<region>-de612dc2/*",
                 "arn:aws:s3:::al2023-<region>/*",
                 "arn:aws:s3:::repo.<region>.emr.amazonaws.com/*",
                 "arn:aws:s3:::prod.<region>.appinfo.src/*",

--- a/vpc_endpoint_policies/ssm_endpoint_policy.json
+++ b/vpc_endpoint_policies/ssm_endpoint_policy.json
@@ -38,8 +38,7 @@
             "Action": [
                 "ssm:Describe*",
                 "ssm:List*",
-                "ssm:Get*",
-                "ssm:Start*"
+                "ssm:Get*"
             ],
             "Effect": "Allow",
             "Resource": [


### PR DESCRIPTION
add ec2 endpoint policy which allows marketplace consumption and amazon images consumption
add s3 actual AL2023 location - the current location doesn't necessary is a name of a bucket
add Start* to SSM - to allow actions such as port forwarding via SSM


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
