### PR TITLE
Add additional AWS-owned S3 buckets to VPCE policy

### DIFF
--- a/vpc_endpoint_policies/README.md
+++ b/vpc_endpoint_policies/README.md
@@ -134,7 +134,7 @@ Example data access patterns:
         * `arn:aws:s3:::aws-elastic-disaster-recovery-<region>/*`,
         * `arn:aws:s3:::aws-elastic-disaster-recovery-hashes-<region>/*`
 
-* *AWS CloudFormation wait conditions.* CloudFormation uses AWS owned Amazon S3 buckets to to monitor resposnes to a [custom resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html) request or a [wait condition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-waitcondition.html). If a template includes custom resources or wait conditions in a VPC, the VPC endpoint policy must allow users to send reponses to the following buckets:
+* *AWS CloudFormation wait conditions.* CloudFormation uses AWS owned Amazon S3 buckets to to monitor responses to a [custom resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html) request or a [wait condition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-waitcondition.html). If a template includes custom resources or wait conditions in a VPC, the VPC endpoint policy must allow users to send responses to the following buckets:
 
     * [AWS owned buckets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-vpce-bucketnames.html#cfn-setting-up-vpc-considerations)
 

--- a/vpc_endpoint_policies/README.md
+++ b/vpc_endpoint_policies/README.md
@@ -134,7 +134,18 @@ Example data access patterns:
         * `arn:aws:s3:::aws-elastic-disaster-recovery-<region>/*`,
         * `arn:aws:s3:::aws-elastic-disaster-recovery-hashes-<region>/*`
 
+* *AWS CloudFormation wait conditions.* CloudFormation uses AWS owned Amazon S3 buckets to to monitor resposnes to a [custom resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html) request or a [wait condition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-waitcondition.html). If a template includes custom resources or wait conditions in a VPC, the VPC endpoint policy must allow users to send reponses to the following buckets:
 
+    * [AWS owned buckets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-vpce-bucketnames.html#cfn-setting-up-vpc-considerations)
+
+        * `arn:aws:s3:::cloudformation-custom-resource-response-<region>/*`, (_Note_: `<region>` does not contain dashes, for example, `uswest2`)
+        * `arn:aws:s3:::cloudformation-waitcondition-<region>/*`,
+
+* *ACM for AWS Nitro Enclaves.* ACM for AWS Nitro Enclaves uses an AWS owned Amazon S3 bucket to distribute a certificate to an EC2-hosted web server.
+
+    * [AWS owned buckets](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-refapp.html#role-cert)
+
+        * `arn:aws:s3:::aws-ec2-enclave-certificate-<region>/*`
 
 ### "Sid": "AllowRequestsByOrgsIdentitiesToAWSResources"
 

--- a/vpc_endpoint_policies/s3_endpoint_policy.json
+++ b/vpc_endpoint_policies/s3_endpoint_policy.json
@@ -76,7 +76,8 @@
                 "arn:aws:s3:::aws-drs-internal-<region>/*",
                 "arn:aws:s3:::aws-drs-internal-hashes-<region>/*",
                 "arn:aws:s3:::aws-elastic-disaster-recovery-<region>/*",
-                "arn:aws:s3:::aws-elastic-disaster-recovery-hashes-<region>/*"
+                "arn:aws:s3:::aws-elastic-disaster-recovery-hashes-<region>/*",
+                "arn:aws:s3:::cloudformation-waitcondition-<region>/*"
             ]
         },
         {

--- a/vpc_endpoint_policies/s3_endpoint_policy.json
+++ b/vpc_endpoint_policies/s3_endpoint_policy.json
@@ -77,7 +77,9 @@
                 "arn:aws:s3:::aws-drs-internal-hashes-<region>/*",
                 "arn:aws:s3:::aws-elastic-disaster-recovery-<region>/*",
                 "arn:aws:s3:::aws-elastic-disaster-recovery-hashes-<region>/*",
-                "arn:aws:s3:::cloudformation-waitcondition-<region>/*"
+                "arn:aws:s3:::cloudformation-waitcondition-<region>/*",
+                "arn:aws:s3:::cloudformation-custom-resource-response-<region>/*",
+                "arn:aws:s3:::aws-ec2-enclave-certificate-<region>-prod/*"
             ]
         },
         {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Per https://aws.amazon.com/blogs/mt/signaling-aws-cloudformation-waitconditions-using-aws-privatelink/, this is an AWS-owned bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
