### PR TITLE
Added Amazon S3 buckets owned by AWS CodeArtifact

### DIFF
--- a/vpc_endpoint_policies/README.md
+++ b/vpc_endpoint_policies/README.md
@@ -150,6 +150,12 @@ Example data access patterns:
 
         * `arn:aws:s3:::aws-ec2-enclave-certificate-<region>/*`
 
+* *AWS CodeArtifact operations.* CodeArtifact uses AWS owned Amazon S3 buckets to host the artifacts and redirects HTTP requests for an artifact repository URL to a presigned URL backed by one of their buckets.
+
+    * [AWS owned buckets](https://docs.aws.amazon.com/codeartifact/latest/ug/create-s3-gateway-endpoint.html)
+
+        * `arn:aws:s3:::assets-<CodeArtifaction-Region-Account>-<region>/*`
+
 ### "Sid":"AllowRequestsByOrgsIdentitiesToAWSResources"
 
 This policy statement allows identities from your Organizations organization to send requests through a VPC endpoint to AWS owned resources. You can list ARNs of AWS owned resources in the `Resource` element of the statement. You can further restrict access by specifying allowed actions in the `Action` element of the statement. 

--- a/vpc_endpoint_policies/s3_endpoint_policy.json
+++ b/vpc_endpoint_policies/s3_endpoint_policy.json
@@ -72,7 +72,20 @@
                 "arn:aws:s3:::aws-elastic-disaster-recovery-hashes-<region>/*",
                 "arn:aws:s3:::cloudformation-waitcondition-<region>/*",
                 "arn:aws:s3:::cloudformation-custom-resource-response-<RegionWithoutDashes>/*",
-                "arn:aws:s3:::aws-ec2-enclave-certificate-<region>-prod/*"
+                "arn:aws:s3:::aws-ec2-enclave-certificate-<region>-prod/*",
+                "arn:aws:s3:::assets-193858265520-us-east-1/*",
+                "arn:aws:s3:::assets-250872398865-us-east-2/*",
+                "arn:aws:s3:::assets-787052242323-us-west-2/*",
+                "arn:aws:s3:::assets-438097961670-eu-west-1/*",
+                "arn:aws:s3:::assets-247805302724-eu-west-2/*",
+                "arn:aws:s3:::assets-762466490029-eu-west-3/*",
+                "arn:aws:s3:::assets-611884512288-eu-north-1/*",
+                "arn:aws:s3:::assets-484130244270-eu-south-1/*",
+                "arn:aws:s3:::assets-769407342218-eu-central-1/*",
+                "arn:aws:s3:::assets-660291247815-ap-northeast-1/*",
+                "arn:aws:s3:::assets-421485864821-ap-southeast-1/*",
+                "arn:aws:s3:::assets-860415559748-ap-southeast-2/*",
+                "arn:aws:s3:::assets-681137435769-ap-south-1/*"
             ]
         },
         {

--- a/vpc_endpoint_policies/s3_endpoint_policy.json
+++ b/vpc_endpoint_policies/s3_endpoint_policy.json
@@ -73,19 +73,7 @@
                 "arn:aws:s3:::cloudformation-waitcondition-<region>/*",
                 "arn:aws:s3:::cloudformation-custom-resource-response-<RegionWithoutDashes>/*",
                 "arn:aws:s3:::aws-ec2-enclave-certificate-<region>-prod/*",
-                "arn:aws:s3:::assets-193858265520-us-east-1/*",
-                "arn:aws:s3:::assets-250872398865-us-east-2/*",
-                "arn:aws:s3:::assets-787052242323-us-west-2/*",
-                "arn:aws:s3:::assets-438097961670-eu-west-1/*",
-                "arn:aws:s3:::assets-247805302724-eu-west-2/*",
-                "arn:aws:s3:::assets-762466490029-eu-west-3/*",
-                "arn:aws:s3:::assets-611884512288-eu-north-1/*",
-                "arn:aws:s3:::assets-484130244270-eu-south-1/*",
-                "arn:aws:s3:::assets-769407342218-eu-central-1/*",
-                "arn:aws:s3:::assets-660291247815-ap-northeast-1/*",
-                "arn:aws:s3:::assets-421485864821-ap-southeast-1/*",
-                "arn:aws:s3:::assets-860415559748-ap-southeast-2/*",
-                "arn:aws:s3:::assets-681137435769-ap-south-1/*"
+                "arn:aws:s3:::assets-<CodeArtifaction-Region-Account>-<region>/*"
             ]
         },
         {


### PR DESCRIPTION
AWS CodeArtifact uses Amazon S3 to store artifacts, cf. https://docs.aws.amazon.com/codeartifact/latest/ug/create-s3-gateway-endpoint.html

*Issue #, if available:*

n/a

*Description of changes:*

Added buckets from Amazon CodeArtifact documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
