### PR TITLE
Adding a new SCP to deny access to S3 SSE-C encryption

### DIFF
--- a/resource_control_policies/resource_based_policies/s3_deny_sse-c.json
+++ b/resource_control_policies/resource_based_policies/s3_deny_sse-c.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",    
+    "Statement": [
+        {
+            "Sid": "DenyS3ServerSideEncryptionCustomer", 
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::<your-bucket-name>/*",
+            "Condition": {
+                "Null": {
+                    "s3:x-amz-server-side-encryption-customer-algorithm": "false"
+                }
+            }
+        }
+    ]
+ }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added an S3 Service Control Policy (SCP) to prevent the use of customer-provided encryption keys (SSE-C) . This security measure ensures all S3 bucket encryption remains under organizational control by blocking client-side encryption key management, reducing the risk of key loss and maintaining consistent encryption standards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
