### PR TITLE
Add functionality for AWS SQS : Prevent unintended exposure of SQS queues

### DIFF
--- a/resource_control_policies/SQS-Deny-deletemessage-outside-org-access.json
+++ b/resource_control_policies/SQS-Deny-deletemessage-outside-org-access.json
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Statement1",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "sqs:DeleteMessage",
+      "Resource": "*",
+      "Condition": {
+        "StringNotEqualsIfExists": {
+          "aws:PrincipalOrgID": "my-org-id"
+        },
+        "BoolIfExists": {
+          "aws:PrincipalIsAWSService": "false"
+        }
+      }
+    }
+  ]
+}

--- a/resource_control_policies/SQS-Deny-sendmessage-outside-org-access.json
+++ b/resource_control_policies/SQS-Deny-sendmessage-outside-org-access.json
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Statement1",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "*",
+      "Condition": {
+        "StringNotEqualsIfExists": {
+          "aws:PrincipalOrgID": "my-org-id"
+        },
+        "BoolIfExists": {
+          "aws:PrincipalIsAWSService": "false"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Examples of AWS SQS Resource Control Policies (RCP)

Prevent unintended exposure of SQS queue access to IAM principals outside the AWS Organization.
Prevent unintended exposure of SQS queue message deletion to IAM principals outside the AWS Organization.
Testing
Creating a Public SQS Queue
A user creates an SQS queue with a public policy (notice "AWS": "*"):

```
{
  "Version": "2012-10-17",
  "Id": "Default",
  "Statement": [
    {
      "Sid": "1",
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "SQS:*",
      "Resource": "arn:aws:sqs:us-east-1:123456789035:pcl_test_2"
    }
  ]
}
```

## Testing RCPs

### Without RCP
A public SQS queue allows a message from an external account:

```
aws sqs send-message \     
--queue-url https://sqs.us-east-1.amazonaws.com/1234567890/test \     
--message-body "Your message content goes here" \    
--region us-east-1
```
Response:


```
{
  "MD5OfMessageBody": "8411112267b148324467",
  "MessageId": "a9f48-4ef7-a5a2-d78328dc07b5"
}
```

### With RCP
After applying an RCP at the organizational level, the same action results in an access denial:

```

aws sqs send-message \    
--queue-url https://sqs.us-east-1.amazonaws.com/1234567890/test \ 
--message-body "Your message content goes here" \    
--region us-east-1
```
Error Response:

```
An error occurred (AccessDenied) when calling the SendMessage operation: 
User: arn:aws:iam::123456789:user/nagtest is not authorized to perform: 
sqs:SendMessage on resource: arn:aws:sqs:us-east-1:333333344444444:test 
with an explicit deny in a resource control policy.
```

More info @ https://nagwww.medium.com/guardrails-in-the-cloud-exploring-aws-resource-control-policies-for-enhanced-security-6f71c8543afe

