### PR TITLE
add: PreventDirectInternetAccessSageMakerNotebook

### DIFF
--- a/service_control_policies/README.md
+++ b/service_control_policies/README.md
@@ -237,3 +237,9 @@ Services such as Lambda, AWS Glue, CloudShell, and SageMaker support different d
 
 This statement is included in the [data_perimeter_governance_policy_2.json](data_perimeter_governance_policy_2.json) and prevents users from creating [Amazon SageMaker domains](https://docs.aws.amazon.com/sagemaker/latest/dg/sm-domain.html) that can access the internet through a VPC managed by SageMaker, or updating SageMaker domains to allow access to the internet through a VPC managed by SageMaker.    
 For more details, see the definition of the parameter [`AppNetworkAccessType`](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_UpdateDomain.html#sagemaker-UpdateDomain-request-AppNetworkAccessType) in the Amazon SageMaker API Reference.
+
+
+### "Sid": "PreventDirectInternetAccessSageMakerNotebook"
+
+This statement is included in the [data_perimeter_governance_policy_2.json](data_perimeter_governance_policy_2.json) and prevents users from creating [Amazon SageMaker Notebooks Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) that can access the internet through a VPC managed by SageMaker.        
+For more details, see [Connect a Notebook Instance in a VPC to External Resources](https://docs.aws.amazon.com/sagemaker/latest/dg/appendix-notebook-and-internet-access.html) in the Amazon SageMaker documentation.

--- a/service_control_policies/data_perimeter_governance_policy_2.json
+++ b/service_control_policies/data_perimeter_governance_policy_2.json
@@ -108,7 +108,8 @@
          ],
         "Resource": "*",
         "Condition": {
-            "StringNotEquals": {
+            "StringNotEqualsIfExists": {
+               "aws:PrincipalTag/dp:exclude": "true",
                "sagemaker:AppNetworkAccessType": "VpcOnly"
             }
          }

--- a/service_control_policies/data_perimeter_governance_policy_2.json
+++ b/service_control_policies/data_perimeter_governance_policy_2.json
@@ -124,6 +124,9 @@
         "Condition": {
             "StringEquals": {
                "sagemaker:DirectInternetAccess": "Enabled"
+            },
+            "StringNotEqualsIfExists": {
+               "aws:PrincipalTag/dp:exclude": "true"
             }
          }
       },

--- a/service_control_policies/data_perimeter_governance_policy_2.json
+++ b/service_control_policies/data_perimeter_governance_policy_2.json
@@ -114,6 +114,19 @@
          }
       },
       {
+         "Sid": "PreventDirectInternetAccessSageMakerNotebook",
+         "Effect": "Deny",
+         "Action": [
+            "sagemaker:CreateNotebookInstance"
+         ],
+        "Resource": "*",
+        "Condition": {
+            "StringEquals": {
+               "sagemaker:DirectInternetAccess": "Enabled"
+            }
+         }
+      },
+      {
          "Sid":"PreventNonVPCDeploymentLambda",
          "Effect":"Deny",
          "Action":[


### PR DESCRIPTION
The objective of this PR is to add the SCP statement `PreventDirectInternetAccessSageMakerNotebook` to [data_perimeter_governance_policy_2.json](data_perimeter_governance_policy_2.json).

The statement `PreventDirectInternetAccessSageMakerNotebook` prevents users from creating [Amazon SageMaker Notebooks Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) that can access the internet through a VPC managed by SageMaker.           
For more details, see [Connect a Notebook Instance in a VPC to External Resources](https://docs.aws.amazon.com/sagemaker/latest/dg/appendix-notebook-and-internet-access.html) in the Amazon SageMaker documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
