### PR TITLE
Use StringLike when matching wildcards

### DIFF
--- a/service_control_policies/data_perimeter_governance_policy_1.json
+++ b/service_control_policies/data_perimeter_governance_policy_1.json
@@ -129,7 +129,7 @@
             "StringNotEqualsIfExists": {
                "aws:PrincipalTag/team": "admin"
             },
-            "ForAnyValue:StringEquals": {
+            "ForAnyValue:StringLike": {
                "aws:TagKeys": [
                   "dp:*",
                   "team"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update condition operator.  To match "dp" prefix on keys we need to use StringLike instead of StringEquals

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
