### PR TITLE
add: PreventNonVPCDeploymentAppRunner

### DIFF
--- a/service_control_policies/README.md
+++ b/service_control_policies/README.md
@@ -226,11 +226,11 @@ This statement is included in the [data_perimeter_governance_policy_2](data_peri
 
 AWS services such as AWS CodeStar Connections do not support deployment within a VPC and provide direct access to the internet that is not controlled by your VPC. You can block the use of such services by using SCPs or implementing your own proxy solution to inspect egress traffic.
 
-### "Sid":"PreventNonVPCDeploymentSageMaker", "Sid":"PreventNonVPCDeploymentGlueJob", "Sid":"PreventNonVPCDeploymentCloudShell", and "Sid":"PreventNonVPCDeploymentLambda"
+### "Sid":"PreventNonVPCDeploymentSageMaker", "Sid":"PreventNonVPCDeploymentGlueJob", "Sid":"PreventNonVPCDeploymentCloudShell", and "Sid":"PreventNonVPCDeploymentLambda", "Sid":"PreventNonVPCAppRunnerService"
 
-These statements are included in the [data_perimeter_governance_policy_2](data_perimeter_governance_policy_2.json) and explicitly deny relevant [Amazon SageMaker](https://aws.amazon.com/sagemaker/), [AWS Glue](https://aws.amazon.com/glue/), [AWS CloudShell](https://aws.amazon.com/cloudshell/) and [AWS Lambda](https://aws.amazon.com/lambda/) operations unless they have VPC configurations specified in the requests. Use these statements to enforce deployment in a VPC for these services.
+These statements are included in the [data_perimeter_governance_policy_2](data_perimeter_governance_policy_2.json) and explicitly deny relevant [Amazon SageMaker](https://aws.amazon.com/sagemaker/), [AWS Glue](https://aws.amazon.com/glue/), [AWS CloudShell](https://aws.amazon.com/cloudshell/), [AWS Lambda](https://aws.amazon.com/lambda/), and [AWS AppRunner](https://aws.amazon.com/apprunner/) operations unless they have VPC configurations specified in the requests. Use these statements to enforce deployment in a VPC for these services.
 
-Services such as Lambda, AWS Glue, CloudShell, and SageMaker support different deployment models. For example, [Amazon SageMaker Studio](https://aws.amazon.com/pm/sagemaker/) and [SageMaker notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) allow direct internet access by default. However, they provide you with the capability to configure them to run within your VPC so that you can inspect requests by using VPC endpoint policies (against identity and resource perimeter controls) and enforce the network perimeter.
+Services such as Lambda, AWS Glue, CloudShell, App Runner, and SageMaker support different deployment models. For example, [Amazon SageMaker Studio](https://aws.amazon.com/pm/sagemaker/) and [SageMaker notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) allow direct internet access by default. However, they provide you with the capability to configure them to run within your VPC so that you can inspect requests by using VPC endpoint policies (against identity and resource perimeter controls) and enforce the network perimeter.
 
 
 ### "Sid": "PreventNonVpcOnlySageMakerDomain"

--- a/service_control_policies/README.md
+++ b/service_control_policies/README.md
@@ -226,7 +226,7 @@ This statement is included in the [data_perimeter_governance_policy_2](data_peri
 
 AWS services such as AWS CodeStar Connections do not support deployment within a VPC and provide direct access to the internet that is not controlled by your VPC. You can block the use of such services by using SCPs or implementing your own proxy solution to inspect egress traffic.
 
-### "Sid":"PreventNonVPCDeploymentSageMaker", "Sid":"PreventNonVPCDeploymentGlueJob", "Sid":"PreventNonVPCDeploymentCloudShell", and "Sid":"PreventNonVPCDeploymentLambda", "Sid":"PreventNonVPCAppRunnerService"
+### "Sid":"PreventNonVPCDeploymentSageMaker", "Sid":"PreventNonVPCDeploymentGlueJob", "Sid":"PreventNonVPCDeploymentCloudShell", and "Sid":"PreventNonVPCDeploymentLambda", "Sid":"PreventNonVPCDeploymentAppRunner"
 
 These statements are included in the [data_perimeter_governance_policy_2](data_perimeter_governance_policy_2.json) and explicitly deny relevant [Amazon SageMaker](https://aws.amazon.com/sagemaker/), [AWS Glue](https://aws.amazon.com/glue/), [AWS CloudShell](https://aws.amazon.com/cloudshell/), [AWS Lambda](https://aws.amazon.com/lambda/), and [AWS AppRunner](https://aws.amazon.com/apprunner/) operations unless they have VPC configurations specified in the requests. Use these statements to enforce deployment in a VPC for these services.
 

--- a/service_control_policies/data_perimeter_governance_policy_2.json
+++ b/service_control_policies/data_perimeter_governance_policy_2.json
@@ -162,6 +162,23 @@
                "cloudshell:VpcIds": "true"
             }
          }
+      },
+      {
+         "Sid": "PreventNonVPCAppRunnerService",
+         "Action": [
+            "apprunner:CreateService",
+            "apprunner:UpdateService"
+         ],
+         "Effect": "Deny",
+         "Resource": "*",
+         "Condition": {   
+            "StringNotEqualsIfExists": {
+               "aws:PrincipalTag/dp:exclude": "true"
+            },
+            "Null": {
+               "apprunner:VpcConnectorArn": "true"
+            }
+         }
       }
    ]
 }

--- a/service_control_policies/data_perimeter_governance_policy_2.json
+++ b/service_control_policies/data_perimeter_governance_policy_2.json
@@ -164,7 +164,7 @@
          }
       },
       {
-         "Sid": "PreventNonVPCAppRunnerService",
+         "Sid": "PreventNonVPCDeploymentAppRunner",
          "Effect": "Deny",
          "Action": [
             "apprunner:CreateService",

--- a/service_control_policies/data_perimeter_governance_policy_2.json
+++ b/service_control_policies/data_perimeter_governance_policy_2.json
@@ -165,11 +165,11 @@
       },
       {
          "Sid": "PreventNonVPCAppRunnerService",
+         "Effect": "Deny",
          "Action": [
             "apprunner:CreateService",
             "apprunner:UpdateService"
          ],
-         "Effect": "Deny",
          "Resource": "*",
          "Condition": {   
             "StringNotEqualsIfExists": {


### PR DESCRIPTION
The objective of this PR is to add the statement `PreventNonVPCAppRunnerService` to [data_perimeter_governance_policy_2.json](data_perimeter_governance_policy_2.json).

[AWS App Runner](https://docs.aws.amazon.com/apprunner/latest/dg/what-is-apprunner.html) allows direct internet access by default but provides the capability to route traffic through a VPC you specify in a [VPC connector](https://docs.aws.amazon.com/apprunner/latest/dg/network-vpc.html#network-vpc.VPC-connector).

The statement `PreventNonVPCAppRunnerService` enforces the usage of a VPC connector to help ensure the App Runner services access internet through your VPC. For more details, see [Enabling VPC access for outgoing traffic](https://docs.aws.amazon.com/apprunner/latest/dg/network-vpc.html) in the App Runner Developer Guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
