### PR TITLE
Fix: Data perimeter tag deny is case-sensitive

### DIFF
--- a/resource_control_policies/data_perimeter_governance_rcp.json
+++ b/resource_control_policies/data_perimeter_governance_rcp.json
@@ -17,30 +17,52 @@
                "aws:PrincipalTag/team": "admin",
                "aws:PrincipalOrgID" : "<my-org-id>"
            },
-           "ForAnyValue:StringLike": {
+           "ForAnyValue:StringEqualsIgnoreCase": {
                "aws:TagKeys": [
-                  "dp:*",
-                  "dP:*",
-                  "Dp:*",
-                  "DP:*",
-                  "team",
-                  "teaM",
-                  "teAm",
-                  "teAM",
-                  "tEam",
-                  "tEaM",
-                  "tEAm",
-                  "tEAM",
-                  "Team",
-                  "TeaM",
-                  "TeAm",
-                  "TeAM",
-                  "TEam",
-                  "TEaM",
-                  "TEAm",
-                  "TEAM"
+                  "team"
                ]
            }
+         }
+      },
+      {
+         "Sid": "ProtectDataPerimeterSessionTags2",
+         "Effect": "Deny",
+         "Principal": "*",
+         "Action": [
+            "sts:TagSession"
+         ],
+         "Resource": "*",
+         "Condition": {
+            "Null": {
+               "SAML:aud": "true"
+           },
+           "StringNotEqualsIfExists": {
+               "aws:PrincipalTag/team": "admin",
+               "aws:PrincipalOrgID" : "<my-org-id>"
+           },
+           "ForAnyValue:StringLike": {
+               "aws:TagKeys": [
+                  "dp:*"
+               ]
+           }
+         }
+      },
+      {
+         "Sid": "EnforceDataPerimeterSessionTagKeyCase",
+         "Effect": "Deny",
+         "Principal": "*",
+         "Action": [
+            "sts:TagSession"
+         ],
+         "Resource": "*",
+         "Condition": {
+            "ForAnyValue:StringLike": {
+               "aws:TagKeys": [
+                  "dP:*",
+                  "Dp:*",
+                  "DP:*"
+               ]
+            }
          }
       }
    ]

--- a/resource_control_policies/data_perimeter_governance_rcp.json
+++ b/resource_control_policies/data_perimeter_governance_rcp.json
@@ -20,7 +20,25 @@
            "ForAnyValue:StringLike": {
                "aws:TagKeys": [
                   "dp:*",
-                  "team"
+                  "dP:*",
+                  "Dp:*",
+                  "DP:*",
+                  "team",
+                  "teaM",
+                  "teAm",
+                  "teAM",
+                  "tEam",
+                  "tEaM",
+                  "tEAm",
+                  "tEAM",
+                  "Team",
+                  "TeaM",
+                  "TeAm",
+                  "TeAM",
+                  "TEam",
+                  "TEaM",
+                  "TEAm",
+                  "TEAM"
                ]
            }
          }

--- a/service_control_policies/data_perimeter_governance_scp.json
+++ b/service_control_policies/data_perimeter_governance_scp.json
@@ -160,7 +160,25 @@
             "ForAnyValue:StringLike": {
                "aws:TagKeys": [
                   "dp:*",
-                  "team"
+                  "dP:*",
+                  "Dp:*",
+                  "DP:*",
+                  "team",
+                  "teaM",
+                  "teAm",
+                  "teAM",
+                  "tEam",
+                  "tEaM",
+                  "tEAm",
+                  "tEAM",
+                  "Team",
+                  "TeaM",
+                  "TeAm",
+                  "TeAM",
+                  "TEam",
+                  "TEaM",
+                  "TEAm",
+                  "TEAM"
                ]
             }
          }

--- a/service_control_policies/data_perimeter_governance_scp.json
+++ b/service_control_policies/data_perimeter_governance_scp.json
@@ -159,26 +159,38 @@
             },
             "ForAnyValue:StringLike": {
                "aws:TagKeys": [
-                  "dp:*",
+                  "dp:*"
+               ]
+            }
+         }
+      },
+      {
+         "Sid": "ProtectDataPerimeterTags2",
+         "Effect": "Deny",
+         "Action": "*",
+         "Resource": "*",
+         "Condition": {
+            "StringNotEqualsIfExists": {
+               "aws:PrincipalTag/team": "admin"
+            },
+            "ForAnyValue:StringEqualsIgnoreCase": {
+               "aws:TagKeys": [
+                  "team"
+               ]
+            }
+         }
+      },
+      {
+         "Sid": "EnforceDataPerimeterTagKeyCase",
+         "Effect": "Deny",
+         "Action": "*",
+         "Resource": "*",
+         "Condition": {
+            "ForAnyValue:StringLike": {
+               "aws:TagKeys": [
                   "dP:*",
                   "Dp:*",
-                  "DP:*",
-                  "team",
-                  "teaM",
-                  "teAm",
-                  "teAM",
-                  "tEam",
-                  "tEaM",
-                  "tEAm",
-                  "tEAM",
-                  "Team",
-                  "TeaM",
-                  "TeAm",
-                  "TeAM",
-                  "TEam",
-                  "TEaM",
-                  "TEAm",
-                  "TEAM"
+                  "DP:*"
                ]
             }
          }


### PR DESCRIPTION
Both policies list dp:* and team in aws:TagKeys. StringLike compares those values exactly. Policies read the same tags back through aws:PrincipalTag/<key>, which folds the key name case-insensitively.

So a request that sets TEAM or DP:exclude:network is not caught by the Deny, and the tag it leaves behind still answers the aws:PrincipalTag/team and aws:PrincipalTag/dp:exclude:network reads that the rest of these examples use. ProtectDataPerimeterTags reads aws:PrincipalTag/team in its own exemption, so today it can be bypassed with the key it is meant to protect.

Both statements stay as they are and list every case spelling: four entries for the two-letter prefix, sixteen for the four-letter key. That is every spelling, because none of d p t e a m has a non-ASCII character that AWS folds onto it. Only i, s and k need more.